### PR TITLE
Fix broken Censys/Shodan/ZoomEye integrations and core bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Use the **zoomeye** parameter to include ZoomEye in the scan
 # cat domain.txt | cf-hero -zoomeye
 ```
 
-Use the **censys** parameter to include Shodan in the scan
+Use the **censys** parameter to include Censys in the scan
 ```
 # cat domain.txt | cf-hero -censys
 ```
@@ -319,7 +319,7 @@ Use the **shodan** parameter to include Shodan in the scan
 # cat domain.txt | cf-hero -shodan
 ```
 
-Use the **securitytrails** parameter to include Shodan in the scan
+Use the **securitytrails** parameter to include SecurityTrails in the scan
 ```
 # cat domain.txt | cf-hero -securitytrails
 ```

--- a/README.md
+++ b/README.md
@@ -354,15 +354,22 @@ create cf-hero.yaml file under $HOME/.config/ directory to set the APIs key
 // content of YAML file should be like;
 
 zoomeye:
-  - "api_key_here"
+  - "api_key_here"           # ZoomEye API v2 key (sent in the API-KEY header)
 securitytrails:
   - "api_key_here"
 shodan:
-  - "api_key_here"
+  - "api_key_here"           # standard Shodan API key (the /dns/domain endpoint requires a paid Membership)
 censys:
-  - "api_key_here"
+  - "censys_pat_here"        # Censys Platform Personal Access Token (PAT)
+  - "organization_id_here"   # optional: Censys Organization ID, required for paid plans
 
 ```
+
+> **Note on Censys:** CF-Hero now uses the [Censys Platform API](https://docs.censys.com/reference/get-started)
+> (the legacy `search.censys.io` API is being sunset in 2026). Generate a Personal Access Token (PAT)
+> from the Censys Platform console and put it as the first `censys` entry. If your account is on a paid
+> plan, add your Organization ID (shown on the API Access page) as the second entry — without it, the API
+> returns Free-tier permissions and may yield no results (HTTP 403).
 
 ## SS
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
 
 	"github.com/musana/cf-hero/pkg/models"
 	"github.com/projectdiscovery/goflags"
@@ -54,31 +56,41 @@ func createGroup(flagSet *goflags.FlagSet, groupName, description string, flags 
 	}
 }
 
-func ReadAPIKeys(source string) []string {
+var (
+	apiKeysOnce sync.Once
+	apiKeys     map[string][]string
+)
+
+// configPath returns the path to the cf-hero config file.
+func configPath() string {
 	home := os.Getenv("HOME")
 	if home == "" {
-		home = os.Getenv("USERPROFILE") // Windows için
+		home = os.Getenv("USERPROFILE") // Windows
 	}
+	return filepath.Join(home, ".config", "cf-hero.yaml")
+}
 
-	configPath := home + "/.config/cf-hero.yaml"
-	f, err := os.ReadFile(configPath)
-	if err != nil {
-		fmt.Printf("[!] Error reading config file %s: %v\n", configPath, err)
-		return nil
-	}
+// loadAPIKeys reads and parses the config file exactly once. Any error is
+// reported a single time rather than on every lookup.
+func loadAPIKeys() {
+	apiKeysOnce.Do(func() {
+		path := configPath()
+		f, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Printf("[!] Error reading config file %s: %v\n", path, err)
+			return
+		}
 
-	var apiKeys map[string][]string
-	err = yaml.Unmarshal(f, &apiKeys)
-	if err != nil {
-		fmt.Printf("[!] Error parsing YAML from %s: %v\n", configPath, err)
-		return nil
-	}
+		if err := yaml.Unmarshal(f, &apiKeys); err != nil {
+			fmt.Printf("[!] Error parsing YAML from %s: %v\n", path, err)
+			apiKeys = nil
+		}
+	})
+}
 
-	keys, ok := apiKeys[source]
-	if !ok {
-		fmt.Printf("[!] No API keys found for source '%s' in %s\n", source, configPath)
-		return nil
-	}
-
-	return keys
+// ReadAPIKeys returns the configured API keys for the given source, or nil if
+// none are configured. The config file is loaded only once and cached.
+func ReadAPIKeys(source string) []string {
+	loadAPIKeys()
+	return apiKeys[source]
 }

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"time"
 
 	"github.com/Danny-Dasilva/CycleTLS/cycletls"
+	"github.com/fatih/color"
 	"golang.org/x/net/html"
 )
 
@@ -30,7 +32,11 @@ func NewHTTPClient(proxy string, targetURL string) *http.Client {
 	}
 
 	if proxy != "" {
-		transport.Proxy = http.ProxyFromEnvironment
+		if proxyURL, err := neturl.Parse(proxy); err == nil {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		} else {
+			color.Yellow("[!] Invalid proxy URL %q, ignoring: %v", proxy, err)
+		}
 	}
 
 	return &http.Client{

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -212,7 +212,7 @@ func (s *Scanner) Start(url string) {
 		}
 
 		if s.Options.DomainList != "" && s.Options.TargetDomain != "" {
-			s.checkDomainList(url, cfIPs[1], actualHTMLTitle)
+			s.checkDomainList(url, cfIPs[0], actualHTMLTitle)
 		}
 
 		// Print final results only for the last domain
@@ -329,58 +329,30 @@ func (s *Scanner) getTXTRecords(domain, url string, cfIP net.IP, actualHTMLTitle
 }
 
 func (s *Scanner) censysSearch(domain, url string, cfIP net.IP, actualHTMLTitle string) {
+	// Censys Platform API. The config "censys" list holds the Personal Access
+	// Token (PAT) as the first entry and, optionally, the Organization ID as
+	// the second entry (required for paid tiers):
+	//   censys:
+	//     - "censys_pat_xxxxxxxx"
+	//     - "your-organization-id"   # optional
 	keys := config.ReadAPIKeys("censys")
 	if len(keys) == 0 || keys[0] == "" {
 		return
 	}
-
-	key := keys[0]
-	keyToBytes := []byte(key)
-	token := base64.StdEncoding.EncodeToString(keyToBytes)
-
-	censysURL := "https://search.censys.io/api/v2/hosts/search?q=" + domain + "&per_page=50&virtual_hosts=EXCLUDE"
-	client := httpClient.NewHTTPClient(s.Options.Proxy, url)
-	resp, err := client.Do(httpClient.RequestBuilder(censysURL, token, s.Options.HTTPMethod, s.Options.UserAgent))
-	if err != nil {
-		if strings.Contains(err.Error(), "giving up after") {
-			color.Yellow("[!] Censys API rate limit exceeded. Please try again later. (%s)", domain)
-		} else {
-			color.Yellow("[!] Error making request to Censys API: %v", err)
-		}
-		return
-	}
-	defer resp.Body.Close()
-
-	// Check response status
-	if resp.StatusCode != 200 {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		var errorResponse struct {
-			Message string `json:"message"`
-		}
-		if err := json.Unmarshal(bodyBytes, &errorResponse); err == nil {
-			if strings.Contains(errorResponse.Message, "exceeded the usage limits") {
-				color.Yellow("[!] Censys API rate limit exceeded: %s", errorResponse.Message)
-			} else {
-				color.Yellow("[!] Censys API error: %s", errorResponse.Message)
-			}
-		} else {
-			color.Yellow("[!] Censys API returned non-200 status code %d: %s", resp.StatusCode, string(bodyBytes))
-		}
-		color.Yellow("[!] HTTP Status: %s", resp.Status)
-		color.Yellow("[!] HTTP Headers:")
-		for key, values := range resp.Header {
-			for _, value := range values {
-				color.Yellow("[!]   %s: %s", key, value)
-			}
-		}
-		return
+	pat := keys[0]
+	var orgID string
+	if len(keys) > 1 {
+		orgID = keys[1]
 	}
 
-	var data models.CensysJSON
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		color.Yellow("[!] Error decoding Censys response: %v", err)
-		return
+	censysURL := "https://api.platform.censys.io/v3/global/search/query"
+	if orgID != "" {
+		censysURL += "?organization_id=" + neturl.QueryEscape(orgID)
 	}
+
+	// CenQL query: match hosts that present the domain in their DNS names or in
+	// a served TLS certificate's leaf names (including subdomains).
+	query := fmt.Sprintf(`host.dns.names: "%s" or host.dns.names: "*.%s" or host.services.tls.certificates.leaf_data.names: "%s"`, domain, domain, domain)
 
 	var stats struct {
 		totalFound       int
@@ -394,9 +366,91 @@ func (s *Scanner) censysSearch(domain, url string, cfIP net.IP, actualHTMLTitle 
 		color.Cyan("\n[*] Censys search results for %s:", domain)
 	}
 
-	for _, cip := range data.Result.Hits {
-		censysIP := net.ParseIP(cip.IP)
-		if censysIP.To4() != nil {
+	client := httpClient.NewHTTPClient(s.Options.Proxy, url)
+	pageToken := ""
+
+	for {
+		requestBody := map[string]interface{}{
+			"query":     query,
+			"page_size": 100,
+		}
+		if pageToken != "" {
+			requestBody["page_token"] = pageToken
+		}
+		jsonBody, err := json.Marshal(requestBody)
+		if err != nil {
+			color.Yellow("[!] Error preparing Censys request body: %v", err)
+			return
+		}
+
+		req, err := http.NewRequest("POST", censysURL, strings.NewReader(string(jsonBody)))
+		if err != nil {
+			color.Yellow("[!] Error creating Censys request: %v", err)
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+pat)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", s.Options.UserAgent)
+		if orgID != "" {
+			req.Header.Set("X-Organization-ID", orgID)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			if strings.Contains(err.Error(), "giving up after") {
+				color.Yellow("[!] Censys API rate limit exceeded. Please try again later. (%s)", domain)
+			} else {
+				color.Yellow("[!] Error making request to Censys API: %v", err)
+			}
+			return
+		}
+
+		// Check response status
+		if resp.StatusCode != 200 {
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			var errorResponse struct {
+				Message string `json:"message"`
+				Detail  string `json:"detail"`
+			}
+			msg := strings.TrimSpace(string(bodyBytes))
+			if err := json.Unmarshal(bodyBytes, &errorResponse); err == nil {
+				if errorResponse.Message != "" {
+					msg = errorResponse.Message
+				} else if errorResponse.Detail != "" {
+					msg = errorResponse.Detail
+				}
+			}
+			switch resp.StatusCode {
+			case 401:
+				color.Yellow("[!] Censys API authentication failed (401). Check your Personal Access Token. %s", msg)
+			case 403:
+				color.Yellow("[!] Censys API access denied (403). A paid plan and Organization ID may be required. %s", msg)
+			case 429:
+				color.Yellow("[!] Censys API rate limit exceeded (429): %s", msg)
+			default:
+				color.Yellow("[!] Censys API returned non-200 status code %d: %s", resp.StatusCode, msg)
+			}
+			return
+		}
+
+		var data models.CensysPlatformResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			resp.Body.Close()
+			color.Yellow("[!] Error decoding Censys response: %v", err)
+			return
+		}
+		resp.Body.Close()
+
+		for _, hit := range data.Result.Hits {
+			if hit.HostV1 == nil {
+				continue
+			}
+			censysIP := net.ParseIP(hit.HostV1.Resource.IP)
+			if censysIP == nil || censysIP.To4() == nil {
+				continue
+			}
 			stats.totalFound++
 			result, _ := dns.IsInCloudflareIPRange(censysIP)
 			if s.Options.Verbose {
@@ -413,6 +467,11 @@ func (s *Scanner) censysSearch(domain, url string, cfIP net.IP, actualHTMLTitle 
 				s.compareTitle(url, censysIP, cfIP, "Censys", actualHTMLTitle)
 			}
 		}
+
+		if data.Result.NextPageToken == "" {
+			break
+		}
+		pageToken = data.Result.NextPageToken
 	}
 
 	if !s.Options.Verbose {
@@ -558,19 +617,28 @@ func (s *Scanner) shodanSearch(domain, url string, cfIP net.IP, actualHTMLTitle 
 			break
 		}
 
+		retryCount++
+		if retryCount == maxRetries {
+			// Retries exhausted. A transport error has no usable response, so
+			// report it and bail. A non-200 response is left open so the status
+			// handler below can surface the real reason (e.g. plan/credits).
+			if err != nil {
+				if resp != nil {
+					resp.Body.Close()
+				}
+				color.Red("[-] Error making request to Shodan API after %d retries: %v", maxRetries, err)
+				return
+			}
+			break
+		}
+
 		if resp != nil {
 			resp.Body.Close()
 		}
 
-		retryCount++
-		if retryCount == maxRetries {
-			color.Red("[-] Error making request to Shodan API after %d retries: %v\n", maxRetries, err)
-			return
-		}
-
 		// Exponential backoff: 1s, 2s, 4s, 8s, 16s
 		waitTime := time.Duration(1<<uint(retryCount-1)) * time.Second
-		color.Yellow("[!] Retrying Shodan API request in %v (attempt %d/%d)...\n", waitTime, retryCount, maxRetries)
+		color.Yellow("[!] Retrying Shodan API request in %v (attempt %d/%d)...", waitTime, retryCount, maxRetries)
 		time.Sleep(waitTime)
 	}
 	defer resp.Body.Close()
@@ -578,7 +646,14 @@ func (s *Scanner) shodanSearch(domain, url string, cfIP net.IP, actualHTMLTitle 
 	// Check response status
 	if resp.StatusCode != 200 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		color.Yellow("[!] Shodan API returned non-200 status code %d: %s\n", resp.StatusCode, string(bodyBytes))
+		var errorResponse struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &errorResponse); err == nil && errorResponse.Error != "" {
+			color.Yellow("[!] Shodan API error (%d): %s", resp.StatusCode, errorResponse.Error)
+		} else {
+			color.Yellow("[!] Shodan API returned non-200 status code %d: %s", resp.StatusCode, string(bodyBytes))
+		}
 		return
 	}
 
@@ -606,11 +681,11 @@ func (s *Scanner) shodanSearch(domain, url string, cfIP net.IP, actualHTMLTitle 
 				result, _ := dns.IsInCloudflareIPRange(ip)
 				if s.Options.Verbose {
 					if result {
-						color.White("[+] IP: %s (First seen: %s, Last seen: %s) (Cloudflare)",
-							record.Value, record.FirstSeen, record.LastSeen)
+						color.White("[+] IP: %s (Last seen: %s) (Cloudflare)",
+							record.Value, record.LastSeen)
 					} else {
-						color.Yellow("[+] IP: %s (First seen: %s, Last seen: %s)",
-							record.Value, record.FirstSeen, record.LastSeen)
+						color.Yellow("[+] IP: %s (Last seen: %s)",
+							record.Value, record.LastSeen)
 					}
 				}
 				if result {
@@ -641,12 +716,13 @@ func (s *Scanner) zoomeyeSearch(domain, url string, cfIP net.IP, actualHTMLTitle
 		return
 	}
 
-	// Base64 encode the query
-	query := fmt.Sprintf("domain=%s", domain)
+	// Base64 encode the query. The domain value must be quoted per ZoomEye's
+	// dork syntax, otherwise values containing dots may be parsed incorrectly.
+	query := fmt.Sprintf(`domain="%s"`, domain)
 	queryBase64 := base64.StdEncoding.EncodeToString([]byte(query))
 
 	page := 1
-	resultsPerPage := 20
+	resultsPerPage := 100
 	var totalResults int
 	var stats struct {
 		totalFound       int
@@ -658,8 +734,9 @@ func (s *Scanner) zoomeyeSearch(domain, url string, cfIP net.IP, actualHTMLTitle
 	for {
 		// Prepare request body
 		requestBody := map[string]interface{}{
-			"qbase64": queryBase64,
-			"page":    page,
+			"qbase64":  queryBase64,
+			"page":     page,
+			"pagesize": resultsPerPage,
 		}
 		jsonBody, err := json.Marshal(requestBody)
 		if err != nil {
@@ -677,6 +754,7 @@ func (s *Scanner) zoomeyeSearch(domain, url string, cfIP net.IP, actualHTMLTitle
 		}
 
 		req.Header.Set("API-KEY", key)
+		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", s.Options.UserAgent)
 
 		resp, err := client.Do(req)
@@ -700,6 +778,13 @@ func (s *Scanner) zoomeyeSearch(domain, url string, cfIP net.IP, actualHTMLTitle
 			return
 		}
 		resp.Body.Close()
+
+		// ZoomEye signals API-level errors (quota, auth, bad query) with a
+		// non-60000 code even on an HTTP 200 response.
+		if data.Code != 60000 {
+			color.Yellow("[!] ZoomEye API error (code %d): %s", data.Code, data.Message)
+			return
+		}
 
 		// Set total results on first page
 		if page == 1 {
@@ -756,8 +841,10 @@ func (s *Scanner) zoomeyeSearch(domain, url string, cfIP net.IP, actualHTMLTitle
 			}
 		}
 
-		// Check if we need to fetch more pages
-		if page*resultsPerPage >= totalResults {
+		// Stop when the API returns a short/empty page or we've covered every
+		// reported result. Guarding on the returned page length avoids an
+		// infinite loop if the reported total is inaccurate.
+		if len(data.Data) < resultsPerPage || page*resultsPerPage >= totalResults {
 			break
 		}
 		page++

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"time"
 )
 
 type Options struct {
@@ -25,18 +24,20 @@ type Options struct {
 	Title          string
 }
 
-type CensysJSON struct {
-	Code   int    `json:"code"`
-	Status string `json:"status"`
+// CensysPlatformResponse models the Censys Platform API
+// (POST https://api.platform.censys.io/v3/global/search/query) response.
+// The legacy search.censys.io v2 API has been deprecated.
+type CensysPlatformResponse struct {
 	Result struct {
 		Hits []struct {
-			IP            string    `json:"ip"`
-			LastUpdatedAt time.Time `json:"last_updated_at"`
+			HostV1 *struct {
+				Resource struct {
+					IP string `json:"ip"`
+				} `json:"resource"`
+			} `json:"host_v1"`
 		} `json:"hits"`
-		Links struct {
-			Next string `json:"next"`
-			Prev string `json:"prev"`
-		} `json:"links"`
+		NextPageToken string `json:"next_page_token"`
+		TotalHits     int    `json:"total_hits"`
 	} `json:"result"`
 }
 
@@ -57,11 +58,13 @@ type SecurityTrailsResponse struct {
 }
 
 type ShodanDNSHistoryResponse struct {
-	Data []struct {
+	Domain string `json:"domain"`
+	Data   []struct {
+		Subdomain string `json:"subdomain"`
 		Type      string `json:"type"`
 		Value     string `json:"value"`
+		Ports     []int  `json:"ports"`
 		LastSeen  string `json:"last_seen"`
-		FirstSeen string `json:"first_seen"`
 	} `json:"data"`
 }
 


### PR DESCRIPTION
## Summary

  This PR repairs all three intelligence-source integrations (Censys, Shodan,
  ZoomEye), which currently fail silently or with misleading errors even when
  valid API keys are configured, and fixes three unrelated core bugs found
  along the way.

  The root causes were a mix of a deprecated API, unparsed error responses that
  hid account/plan limitations, and incorrect request formatting. After these
  changes each integration correctly reaches its API and reports the actual
  reason on failure (e.g. plan restriction, insufficient credits) instead of
  failing silently.

  ## Changes

  ### Censys — migrate to the Censys Platform API
  The legacy `search.censys.io/api/v2/hosts/search` endpoint is being sunset in
  2026, and modern Censys credentials are Personal Access Tokens (PATs), not the
  old `API_ID:API_SECRET` Basic-auth pair the code base64-encoded.

  - Switch to `POST https://api.platform.censys.io/v3/global/search/query`
  - Use `Authorization: Bearer <PAT>` instead of Basic auth
  - Build a CenQL query matching the domain in DNS names and TLS cert leaf names
    (incl. subdomains)
  - Cursor-based pagination via `next_page_token`
  - Optional Organization ID (required for paid plans) as a second `censys`
    config entry, sent as `X-Organization-ID` / `organization_id`
  - Clear 401 / 403 / 429 error messages

  ### Shodan
  - Remove the phantom `first_seen` field — the `/dns/domain` endpoint only
    returns `last_seen`, so it always decoded empty (and printed blank in
    verbose output)
  - Add `subdomain` / `ports` to the response model
  - Parse the `{"error": "..."}` body so the real cause is shown (e.g.
    "Requires membership or higher to access")
  - Fix the retry loop, which reported exhausted non-200 responses as a `nil`
    error and hid the actual status/body

  ### ZoomEye (v2)
  - Quote the domain in the dork (`domain="example.com"`) so values with dots
    parse correctly
  - Send `Content-Type: application/json`
  - Send an explicit `pagesize` — the API defaults to 10 while the code assumed
    20, causing under-pagination that skipped results
  - Check the API-level response `code` (`60000` == success); ZoomEye returns
    errors (quota, auth, bad query) on HTTP 200
  - Make the pagination loop safe against short/empty pages

  ### Core bug fixes
  - **Panic:** `checkDomainList` indexed `cfIPs[1]`, panicking whenever a domain
    has only one Cloudflare A record (the common case) — use `cfIPs[0]`
  - **Log spam:** `ReadAPIKeys` re-read the config file and printed errors on
    every call (per source, per domain) — load once via `sync.Once` and cache
  - **Proxy ignored:** `NewHTTPClient` set `http.ProxyFromEnvironment` instead of
    using the `-px` value — parse and use the provided proxy URL

  ### Docs
  - Document the new Censys PAT + Organization ID config format and the Shodan
    membership requirement for the `/dns/domain` endpoint

  ## Testing

  - `go build ./...` and `go vet ./...` clean
  - Verified live against a Cloudflare-fronted domain: all three sources now
    reach their APIs correctly and surface accurate, actionable errors when the
    account lacks the required access (Censys Org ID, Shodan membership, ZoomEye
    credits)

  ## Notes for reviewers / config change

  The `censys` config entry now expects a Censys **Platform PAT** (not the old
  `API_ID:API_SECRET`), with an optional Organization ID as a second list item:

  ```yaml
  censys:
    - "censys_pat_here"
    - "organization_id_here"   # optional, required for paid plans

  ---

  A couple of things to consider before opening it upstream:
  - The **Censys config format is a breaking change** for existing users (PAT vs. ID:secret) — I called that out in the
  "Notes for reviewers" section so the maintainer can flag it in release notes.